### PR TITLE
Sanitize doc

### DIFF
--- a/src/js/NoteTransaction.js
+++ b/src/js/NoteTransaction.js
@@ -31,7 +31,7 @@ export default class NoteTransaction {
       const { type, cursorToEnd } = tr.getMeta("toggle-note");
       this.handleToggle(type, cursorToEnd, oldState);
     } else if (tr.getMeta("paste") || tr.getMeta(this.historyPlugin)) {
-      this.handlePaste(oldState);
+      this.handlePaste();
     } else {
       this.handleInput(oldState);
     }
@@ -245,9 +245,9 @@ export default class NoteTransaction {
      * Then rebuild this range my removing all the notes and adding them
      * back in
      */
-  handlePaste(oldState) {
+  handlePaste() {
     const { noteTracker, tr, markType } = this;
-    const rebuildRange = noteTracker.rebuildRange(oldState, tr);
+    const rebuildRange = noteTracker.rebuildRange(tr);
 
     if (rebuildRange) {
       const { from, to } = rebuildRange;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,11 +1,17 @@
 import { Plugin } from "prosemirror-state";
+import { Slice } from "prosemirror-model";
 import NoteTracker from "./NoteTracker";
 import NoteTransaction from "./NoteTransaction";
 import { createDecorateNotes } from "./utils/DecorationUtils";
 import clickHandler from "./clickHandler";
-import { notesFromDoc, sanitizeDoc } from "./utils/StateUtils";
+import {
+  notesFromDoc,
+  sanitizeNode,
+  sanitizeFragment
+} from "./utils/StateUtils";
 import { createNoteMark } from "./utils/SchemaUtils";
 import SharedNoteStateTracker from "./SharedNoteStateTracker";
+import v4 from "uuid/v4";
 
 const toggleNote = key => (type, cursorToEnd = false) => (state, dispatch) =>
   dispatch
@@ -129,7 +135,9 @@ const buildNoter = (
     plugin: new Plugin({
       props: {
         decorations: noteDecorator,
-        handleClick: handleClick && clickHandler(noteTracker, handleClick)
+        handleClick: handleClick && clickHandler(noteTracker, handleClick),
+        transformPasted: ({ content, openStart, openEnd }) =>
+          new Slice(sanitizeFragment(content, markType, v4), openStart, openEnd)
       },
       filterTransaction: (...args) =>
         noteTransaction.filterTransaction(...args),
@@ -143,4 +151,4 @@ const buildNoter = (
   };
 };
 
-export { createNoteMark, buildNoter, toggleNote, sanitizeDoc };
+export { createNoteMark, buildNoter, toggleNote, sanitizeNode };

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,7 +11,6 @@ import {
 } from "./utils/StateUtils";
 import { createNoteMark } from "./utils/SchemaUtils";
 import SharedNoteStateTracker from "./SharedNoteStateTracker";
-import v4 from "uuid/v4";
 
 const toggleNote = key => (type, cursorToEnd = false) => (state, dispatch) =>
   dispatch
@@ -137,7 +136,7 @@ const buildNoter = (
         decorations: noteDecorator,
         handleClick: handleClick && clickHandler(noteTracker, handleClick),
         transformPasted: ({ content, openStart, openEnd }) =>
-          new Slice(sanitizeFragment(content, markType, v4), openStart, openEnd)
+          new Slice(sanitizeFragment(content, markType), openStart, openEnd)
       },
       filterTransaction: (...args) =>
         noteTransaction.filterTransaction(...args),

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,7 +3,7 @@ import NoteTracker from "./NoteTracker";
 import NoteTransaction from "./NoteTransaction";
 import { createDecorateNotes } from "./utils/DecorationUtils";
 import clickHandler from "./clickHandler";
-import { notesFromDoc } from "./utils/StateUtils";
+import { notesFromDoc, sanitizeDoc } from "./utils/StateUtils";
 import { createNoteMark } from "./utils/SchemaUtils";
 import SharedNoteStateTracker from "./SharedNoteStateTracker";
 
@@ -143,4 +143,4 @@ const buildNoter = (
   };
 };
 
-export { createNoteMark, buildNoter, toggleNote };
+export { createNoteMark, buildNoter, toggleNote, sanitizeDoc };

--- a/src/js/utils/StateUtils.js
+++ b/src/js/utils/StateUtils.js
@@ -1,6 +1,9 @@
 import { AllSelection } from "prosemirror-state";
 import { Fragment } from "prosemirror-model";
 
+// Runs through a Fragment's nodes and runs `updater` on them,
+// which is expected to return a node - either the same one or a modified one -
+// which is then added in place of the old node
 const updateFragmentNodes = updater => prevFrag => {
   let frag = Fragment.empty;
 
@@ -16,6 +19,8 @@ const updateFragmentNodes = updater => prevFrag => {
   return frag;
 };
 
+// Changes the attributes on a Mark or MarkType on a node if it exists on that
+// node
 const updateNodeMarkAttrs = (node, mark, attrs = {}) =>
   mark.isInSet(node.marks)
     ? node.mark(
@@ -44,6 +49,10 @@ export const sanitizeFragment = (frag, markType, getId = defaultGetId()) => {
   // the current id of the node according to the input document
   let currentNoteId = null;
 
+  // This will return an updated id for this id depending on whether it's been
+  // seen before in a previous non-contiguous note range, if it's been seen
+  // before then a new id will be generated and used for this id while the range
+  // is contiguous
   const getAdjustNoteId = id => {
     if (id === currentNoteId) {
       return idMap[id];
@@ -67,6 +76,8 @@ export const sanitizeFragment = (frag, markType, getId = defaultGetId()) => {
       });
     }
 
+    // if we're in a text node and we don't have a noteMark then assume we are
+    // not in a note and close the range
     if (node.isText) {
       closeNote();
     }
@@ -75,9 +86,11 @@ export const sanitizeFragment = (frag, markType, getId = defaultGetId()) => {
   })(frag);
 };
 
+// Similar to sanitizeFragment but allows a node to be passed instead
 export const sanitizeNode = (node, markType, getId) =>
   node.copy(sanitizeFragment(node.content, markType, getId));
 
+// Return an array of all of the new ranges in a document [[start, end], ...]
 export const getInsertedRanges = ({ mapping }) => {
   let ranges = [];
   mapping.maps.forEach((stepMap, i) => {

--- a/test/prosemirror-noter-plugin.spec.js
+++ b/test/prosemirror-noter-plugin.spec.js
@@ -522,38 +522,45 @@ describe("Noter Plugin", () => {
   });
 
   describe("sanitizeNode", () => {
+    const getID = () => {
+      let id = 10;
+      return () => {
+        return id ++;
+      };
+    };
+
     it("gets correct notes from a document", () => {
       const input = t(
         p(
-          "foo",
-          note({ id: 1 }, "bar"),
-          "more",
-          note({ id: 2 }, "bar")
+          "f",
+          note({ id: 1 }, "a"),
+          "g",
+          note({ id: 2 }, "b")
         ),
         p(
-          note({ id: 2 }, "bar"),
-          "hi",
-          note({ id: 1 }, "bar"),
-          "hi",
-          note({ id: 1 }, "bar")
+          note({ id: 2 }, "c"),
+          "h",
+          note({ id: 1 }, "d"),
+          "i",
+          note({ id: 1 }, "e")
         )
       );
       const output = t(
         p(
-          "foo",
-          note({ id: 1 }, "bar"),
-          "more",
-          note({ id: 2 }, "bar")
+          "f",
+          note({ id: 1 }, "a"),
+          "g",
+          note({ id: 2 }, "b")
         ),
         p(
-          note({ id: 2 }, "bar"),
-          "hi",
-          note({ id: 3 }, "bar"),
-          "hi",
-          note({ id: 4 }, "bar")
+          note({ id: 2 }, "c"),
+          "h",
+          note({ id: 10 }, "d"),
+          "i",
+          note({ id: 11 }, "e")
         )
       );
-      expect(sanitizeNode(input, noteSchema.marks.note)).toEqual(output);
+      expect(sanitizeNode(input, noteSchema.marks.note, getID())).toEqual(output);
     })
   });
 });

--- a/test/prosemirror-noter-plugin.spec.js
+++ b/test/prosemirror-noter-plugin.spec.js
@@ -9,7 +9,7 @@ import {
 } from "prosemirror-state";
 import { nodes, marks } from "prosemirror-schema-basic";
 import { TestState, removeTags } from "./helpers/prosemirror";
-import { createNoteMark, buildNoter } from "../src/js";
+import { createNoteMark, buildNoter, sanitizeDoc } from "../src/js";
 import SharedNoteStateTracker from "../src/js/SharedNoteStateTracker";
 
 const noteSchema = new Schema({
@@ -519,5 +519,41 @@ describe("Noter Plugin", () => {
       s => s.delete(2),
       t(p("foo", note({ id: 1 }, "r"), "more"))
     );
+  });
+
+  describe("sanitizeDoc", () => {
+    it("gets correct notes from a document", () => {
+      const input = t(
+        p(
+          "foo",
+          note({ id: 1 }, "bar"),
+          "more",
+          note({ id: 2 }, "bar")
+        ),
+        p(
+          note({ id: 2 }, "bar"),
+          "hi",
+          note({ id: 1 }, "bar"),
+          "hi",
+          note({ id: 1 }, "bar")
+        )
+      );
+      const output = t(
+        p(
+          "foo",
+          note({ id: 1 }, "bar"),
+          "more",
+          note({ id: 2 }, "bar")
+        ),
+        p(
+          note({ id: 2 }, "bar"),
+          "hi",
+          note({ id: 3 }, "bar"),
+          "hi",
+          note({ id: 4 }, "bar")
+        )
+      );
+      expect(sanitizeDoc(input, noteSchema.marks.note)).toEqual(output);
+    })
   });
 });

--- a/test/prosemirror-noter-plugin.spec.js
+++ b/test/prosemirror-noter-plugin.spec.js
@@ -9,7 +9,7 @@ import {
 } from "prosemirror-state";
 import { nodes, marks } from "prosemirror-schema-basic";
 import { TestState, removeTags } from "./helpers/prosemirror";
-import { createNoteMark, buildNoter, sanitizeDoc } from "../src/js";
+import { createNoteMark, buildNoter, sanitizeNode } from "../src/js";
 import SharedNoteStateTracker from "../src/js/SharedNoteStateTracker";
 
 const noteSchema = new Schema({
@@ -521,7 +521,7 @@ describe("Noter Plugin", () => {
     );
   });
 
-  describe("sanitizeDoc", () => {
+  describe("sanitizeNode", () => {
     it("gets correct notes from a document", () => {
       const input = t(
         p(
@@ -553,7 +553,7 @@ describe("Noter Plugin", () => {
           note({ id: 4 }, "bar")
         )
       );
-      expect(sanitizeDoc(input, noteSchema.marks.note)).toEqual(output);
+      expect(sanitizeNode(input, noteSchema.marks.note)).toEqual(output);
     })
   });
 });


### PR DESCRIPTION
This exposes a function `sanitizeNode` that can be applied to a document (or any node) before adding that document to the `EditorState` in order to sanitize it: i.e. make sure that two non-contiguous ranges don't have the same id as each other.

This behaviour has also been added to pasted input too through the `transformPasted` plugin prop, as this is another source of untrusted HTML.

One major change here is the little algorithm for finding inserted ranges. This was breaking paste behaviour both for this PR and there was another bug that would break noting that would occasionally happen when pasting a document back over itself (and potentially other edge cases). The previous version that used diffing wouldn't work when you were pasting something that _looked_ the same as previous version so the ranges would not be correct in this case.