### PR TITLE
Ensure changes to note meta trigger a rerender of the widget decorations

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,7 +2,7 @@ import { Plugin, PluginKey } from "prosemirror-state";
 import { Slice } from "prosemirror-model";
 import NoteTracker from "./NoteTracker";
 import NoteTransaction from "./NoteTransaction";
-import { createDecorateNotes } from "./utils/DecorationUtils";
+import { createDecorateNotes, MetaIdKey } from "./utils/DecorationUtils";
 import clickHandler from "./clickHandler";
 import {
   notesFromDoc,
@@ -35,7 +35,9 @@ const setNotesMeta = key => (specs = []) => (state, dispatch) =>
     : true;
 
 const setNoteMeta = key => (id, meta) =>
-  setNotesMeta(key)([{ id, meta: Object.assign({}, meta, { id: v4() }) }]);
+  setNotesMeta(key)([
+    { id, meta: Object.assign({}, meta, { [MetaIdKey]: v4() }) }
+  ]);
 
 const collapseAllNotes = key => () => (state, dispatch) => {
   // @TODO: This is searching the entire doc for notes every time.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,6 +11,7 @@ import {
 } from "./utils/StateUtils";
 import { createNoteMark } from "./utils/SchemaUtils";
 import SharedNoteStateTracker from "./SharedNoteStateTracker";
+import v4 from "uuid/v4";
 
 const toggleNote = key => (type, cursorToEnd = false) => (state, dispatch) =>
   dispatch
@@ -33,7 +34,8 @@ const setNotesMeta = key => (specs = []) => (state, dispatch) =>
       )
     : true;
 
-const setNoteMeta = key => (id, meta) => setNotesMeta(key)([{ id, meta }]);
+const setNoteMeta = key => (id, meta) =>
+  setNotesMeta(key)([{ id, meta: Object.assign({}, meta, { id: v4() }) }]);
 
 const collapseAllNotes = key => () => (state, dispatch) => {
   // @TODO: This is searching the entire doc for notes every time.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,7 +11,7 @@ import {
 } from "./utils/StateUtils";
 import { createNoteMark } from "./utils/SchemaUtils";
 import SharedNoteStateTracker from "./SharedNoteStateTracker";
-import v4 from "uuid/v4";
+import uuid from "uuid/v4";
 
 const toggleNote = key => (type, cursorToEnd = false) => (state, dispatch) =>
   dispatch
@@ -36,7 +36,7 @@ const setNotesMeta = key => (specs = []) => (state, dispatch) =>
 
 const setNoteMeta = key => (id, meta) =>
   setNotesMeta(key)([
-    { id, meta: Object.assign({}, meta, { [MetaIdKey]: v4() }) }
+    { id, meta: Object.assign({}, meta, { [MetaIdKey]: uuid() }) }
   ]);
 
 const collapseAllNotes = key => () => (state, dispatch) => {

--- a/src/js/utils/DecorationUtils.js
+++ b/src/js/utils/DecorationUtils.js
@@ -24,7 +24,7 @@ const createNoteWrapper = (
 
   // A unique key for the widget. It must change to force a render
   // every time we'd like the cursor behaviour to change.
-  const key = `${id}-${sideAdjustedForPluginPriority}`;
+  const key = `${id}-${sideAdjustedForPluginPriority}-${meta.id}`;
 
   const toDom = () => {
     const element = document.createElement("span");

--- a/src/js/utils/DecorationUtils.js
+++ b/src/js/utils/DecorationUtils.js
@@ -1,5 +1,7 @@
 import { DecorationSet, Decoration } from "prosemirror-view";
 
+export const MetaIdKey = Symbol("meta-id-key");
+
 const createNoteWrapper = (
   meta,
   cursorPos,
@@ -22,9 +24,11 @@ const createNoteWrapper = (
   const sideAdjustedForPluginPriority =
     sideToRender + (pluginPriority / Number.MAX_SAFE_INTEGER) * Math.sign(side);
 
+  const maybeMetaKey = meta[MetaIdKey] ? `-${meta[MetaIdKey]}` : "";
+
   // A unique key for the widget. It must change to force a render
   // every time we'd like the cursor behaviour to change.
-  const key = `${id}-${sideAdjustedForPluginPriority}-${meta.id}`;
+  const key = `${id}-${sideAdjustedForPluginPriority}${maybeMetaKey}`;
 
   const toDom = () => {
     const element = document.createElement("span");

--- a/src/js/utils/DecorationUtils.js
+++ b/src/js/utils/DecorationUtils.js
@@ -24,6 +24,7 @@ const createNoteWrapper = (
   const sideAdjustedForPluginPriority =
     sideToRender + (pluginPriority / Number.MAX_SAFE_INTEGER) * Math.sign(side);
 
+  // If the meta has changed, a unique key will be set to force a rerender.
   const maybeMetaKey = meta[MetaIdKey] ? `-${meta[MetaIdKey]}` : "";
 
   // A unique key for the widget. It must change to force a render

--- a/src/js/utils/StateUtils.js
+++ b/src/js/utils/StateUtils.js
@@ -1,6 +1,6 @@
 import { AllSelection } from "prosemirror-state";
 import { Fragment } from "prosemirror-model";
-import v4 from "uuid/v4";
+import uuid from "uuid/v4";
 
 // Runs through a Fragment's nodes and runs `updater` on them,
 // which is expected to return a node - either the same one or a modified one -
@@ -37,7 +37,7 @@ const updateNodeMarkAttrs = (node, mark, attrs = {}) =>
 // e.g. <note id="1">test</note> some <note id="1">stuff</note>
 // results in
 // e.g. <note id="1">test</note> some <note id="2">stuff</note>
-const sanitizeFragmentInner = (frag, markType, createId = v4) => {
+const sanitizeFragmentInner = (frag, markType, createId = uuid) => {
   let idMap = {};
   // the current id of the node according to the input document
   let currentNoteId = null;

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -4,7 +4,7 @@ export const cloneDeep = val => {
   if (val instanceof Array) {
     return val.map(cloneDeep);
   } else if (val instanceof Object) {
-    return Object.keys(val).reduce(
+    return [...Object.getOwnPropertySymbols(val), ...Object.keys(val)].reduce(
       (out, key) =>
         Object.assign({}, out, {
           [key]: cloneDeep(val[key])


### PR DESCRIPTION
Previously, changes to note meta did not necessarily trigger a rerender of the widget decorations. This caused problems when changes to note meta were intended to change properties on those decorations.

This PR adds a Symbol id which changes each time `setNoteMeta` is called, ensuring that the relevant widget decorations are rerendered each time the meta changes.