### PR TITLE
Fix demo link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 /dist/
 *.log
 .vs
+.idea

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin adds the ability to have ranges added to the document that expand and contract around dependent on the input. These notes are represented as `marks` in the document.
 
-Very basic demo [here](http://guardian.github.com/prosemirror-noting)
+Very basic demo [here](https://guardian.github.io/prosemirror-noting/)
 
 ---
 


### PR DESCRIPTION
## What does this change?

Updates the prosemiror demo link. 
Fixes https://github.com/guardian/prosemirror-noting/issues/31